### PR TITLE
add python path so that conf.py works form any directory

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ import sys, os
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 sys.path.append("docs")
+sys.path.append(".")
 extensions = [
         'sphinx.ext.autodoc', 
         'sphinx.ext.intersphinx', 


### PR DESCRIPTION
This addeds the current dir . to the python path allowing the custom sphinx module to work.  This will allow readthedocs.org to work with this repo. 
