### PR TITLE
add documentation for new eventchannel log format

### DIFF
--- a/docs/manual/monitoring/file-log-monitoring.rst
+++ b/docs/manual/monitoring/file-log-monitoring.rst
@@ -45,6 +45,17 @@ and the location is the name of the event log. Example:
         <log_format>eventlog</log_format>
     </localfile>
 
+Windows EventChannel Example 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To monitor a Windows event log on Windows Vista or greater, you have the possibility to use the "eventchannel" log format and the location is the name of the event log. This is the only way to monitor Applications and Services logs. If the file name contains a "%4", replace it with "/". Example:
+
+.. code-block:: xml 
+
+    <localfile>
+        <location>Microsoft-Windows-PrintService/Operational</location>
+        <log_format>eventchannel</log_format>
+    </localfile>
 
 Multiple Files Example 
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/syntax/ossec_config.localfile.trst
+++ b/docs/syntax/ossec_config.localfile.trst
@@ -53,6 +53,14 @@
       - eventlog 
           This is used for Microsoft Windows eventlog format.
 
+      .. _logformat_eventchannel:
+
+      - eventchannel
+          This is used for Microsoft Windows eventlogs, using the new EventApi. This means that it can monitor both standard "Windows" eventlogs, but also more recent "Application and Services" logs.
+
+      .. warning::
+          ``eventchannel`` cannot be used on Windows systems older than Vista.
+
       .. _logformat_mysql:
 
       - mysql_log 
@@ -169,5 +177,22 @@
 
     The output from an event will be stored in an internal database. Every time the same event is received, the output is compared to the previous output. If the output has changed an alert will be generated.
 
+.. _only-future-events:
+.. xml:element:: only-future-events
 
+    Only used with the ``eventchannel`` log format. By default, this kind of log format will read, when OSSEC starts, all events that logcollector missed since it was last stopped. It is possible to set ``only-future-events`` to ``yes`` in order to prevent this behaviour. When set to ``yes``, OSSEC will only receive events that occured after the start of logcollector.
 
+.. _query:
+.. xml:element:: query
+
+    Only used with the ``eventchannel`` log format. It is possible to specify a XPATH query following the event schema (see `Microsoft's documentation <http://msdn.microsoft.com/en-us/library/windows/desktop/aa385201%28v=vs.85%29.aspx>`_) in order to filter the events that OSSEC will process.
+
+    For example, the following configuration will only process events with an ID of 7040:
+
+    .. code-block:: console
+
+      <localfile>
+        <location>System</location>
+        <log_format>eventchannel</log_format>
+        <query>Event/System[EventID=7040]</query>
+      </localfile>


### PR DESCRIPTION
This adds documentation for the new `eventchannel` log format that was merged recently.
