### PR TITLE
fix Download and Support links in ossec_links.html

### DIFF
--- a/docs/_themes/sphinxdoc/ossec_links.html
+++ b/docs/_themes/sphinxdoc/ossec_links.html
@@ -13,8 +13,8 @@
         <ul>
             <li><a href="http://www.ossec.net">Home</a></li> 
             <!--<li><a href="http://www.ossec.net/wiki/OSSEC">Wiki</a></li> -->
-            <li><a href="/?page_id=19">Downloads</a></li> 
-            <li><a href="/?page_id=21">Support</a></li> 
+            <li><a href="http://www.ossec.net/?page_id=19">Downloads</a></li> 
+            <li><a href="http://www.ossec.net/?page_id=21">Support</a></li> 
         </ul>
     </li>
 </ul>


### PR DESCRIPTION
Change relative path to absolute one so they point back to www.ossec.net
