### PR TITLE
Quick and dirty faq entry for error:

### DIFF
--- a/docs/faq/agents.rst
+++ b/docs/faq/agents.rst
@@ -14,6 +14,10 @@ When looking at historical alerts you don't want to associate alerts from one sy
 
 
 
+ossec-logcollector(PID): ERROR: Unable to open file '/queue/ossec/.agent_info'
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Ensure there is a <server-ip> configured in the agent's /var/ossec/etc/ossec.conf, and that the IP is correct.
 
 
 


### PR DESCRIPTION
ossec-logcollector(1103): ERROR: Unable to open file '/queue/ossec/.agent_info'.
Brought up on the list by Glenn Ford (gmfpanda gmail).
