### PR TITLE
Docs for 'use_fqdn' syslog option

### DIFF
--- a/docs/syntax/ossec_config.syslog_output.trst
+++ b/docs/syntax/ossec_config.syslog_output.trst
@@ -60,6 +60,8 @@
 
     - **Allowed** default, cef, splunk, json
 
+    - **Example:**
+
     .. code-block:: xml
 
     	<syslog_output>

--- a/docs/syntax/ossec_config.syslog_output.trst
+++ b/docs/syntax/ossec_config.syslog_output.trst
@@ -48,6 +48,14 @@
 
     - **Allowed:** Any valid logfile location
 
+.. xml:element:: use_fqdn
+
+    - By default, ossec truncates the hostname at the first period ('.') when generating syslog messages. Setting this option to 'yes' will cause it to use the full hostname configured on the server.
+
+    - **Default** no
+
+    - **Allowed** yes, no
+
 .. xml:element:: format
 
     - Format of alert output. The default format is "default", or full syslog output.


### PR DESCRIPTION
As requested. Is there anywhere else that needs the update? I'm unfamiliar with the layout, but I didn't spot anything with a few greps.