### PR TITLE
Jsonout adjustments

### DIFF
--- a/docs/manual/output/json-alert-log-output.rst
+++ b/docs/manual/output/json-alert-log-output.rst
@@ -3,6 +3,11 @@
 Storing alerts as JSON
 =========================
 
+.. note::
+
+   This feature first appeared in OSSEC 2.9.
+
+
 Sometimes you want to easily consume OSSEC alerts in other programs.
 With the json output, you can write alerts as a newline separated json file which other programs can easily consume.
 
@@ -47,3 +52,4 @@ You will still have the legacy alerts.log and any custom log formats you've crea
 The files are md5 and sha1 checksummed and compressed once daily (just like the legacy alerts.log).
 
 That's it. 
+

--- a/docs/syntax/ossec_config.global.trst
+++ b/docs/syntax/ossec_config.global.trst
@@ -7,6 +7,10 @@
     **Default:** no
     **Allowed:** yes/no
 
+.. note::
+
+   This feature first appeared in OSSEC 2.9.
+
 .. xml:element:: email_notification
 
     Enable or disable e-mail alerting.

--- a/docs/syntax/ossec_config.global.trst
+++ b/docs/syntax/ossec_config.global.trst
@@ -1,16 +1,5 @@
 .. xml:element:: global 
 
-.. xml:element:: jsonout_output
-
-    Enable or disable writing of json-formated alerts at /var/ossec/logs/alerts/alerts.json
-
-    **Default:** no
-    **Allowed:** yes/no
-
-.. note::
-
-   This feature first appeared in OSSEC 2.9.
-
 .. xml:element:: email_notification
 
     Enable or disable e-mail alerting.
@@ -18,7 +7,6 @@
     **Default:** no
 
     **Allowed:** yes/no
-
 
 .. xml:element:: email_to
 
@@ -124,6 +112,17 @@
     **Default:** 8
 
     **Allowed:** Any level from 0 to 16 
+
+.. xml:element:: jsonout_output
+
+    Enable or disable writing of json-formated alerts at /var/ossec/logs/alerts/alerts.json
+
+    **Default:** no
+    **Allowed:** yes/no
+
+.. note::
+
+   This feature first appeared in OSSEC 2.9.
 
 .. xml:element:: prelude_output 
 


### PR DESCRIPTION
Mark it as new for 2.9.
There's no reason it should be listed first on the global syntax page.
Might be re-writing the manual page soon.