### PR TITLE
Jsonout: fix paste-o in the syntax

### DIFF
--- a/docs/manual/output/index.rst
+++ b/docs/manual/output/index.rst
@@ -9,9 +9,9 @@ Contents:
 .. toctree::
     :maxdepth: 2
 
-    json-alert-log-output
     syslog-output
     email-output 
+    json-alert-log-output
     database-output 
     reports-email-output
     picviz-output

--- a/docs/manual/output/json-alert-log-output.rst
+++ b/docs/manual/output/json-alert-log-output.rst
@@ -34,7 +34,7 @@ File: /var/ossec/logs/ossec.conf
 
     <ossec_config>
       <global>
-        <jsonout_output>yes</syslog_output>
+        <jsonout_output>yes</jsonout_output>
         ...
       </global>
       ...


### PR DESCRIPTION
syslog_output to jsonout
Also, move the jsonout document link to a more respectable location in the index.

This should fully fix issue #83 