### PR TITLE
Documentation for decoder_dir was incorrect. 

### DIFF
--- a/docs/syntax/ossec_config.rules.trst
+++ b/docs/syntax/ossec_config.rules.trst
@@ -81,7 +81,7 @@
     - *pattern*: is a regex match string use to detemine if a file needs to be 
       loaded. 
         
-        - *Defaults*: regex "_decoder.xml$" is used unless another one is specified. 
+        - *Defaults*: regex ".xml$" is used unless another one is specified. 
       
     **Allowed:** Path to a directoy of decoder files 
 


### PR DESCRIPTION
Brought to my attention by autodidactic <theoriginalguru gmail> on the user-list.