### PR TITLE
Tweaks and a missing version warning

### DIFF
--- a/docs/manual/agent/agentless-scripts.rst
+++ b/docs/manual/agent/agentless-scripts.rst
@@ -607,7 +607,7 @@ Before we add this new script to OSSEC configuration we need to test it.
 
 Due to not making use of the of the $arg variable in the way that ssh_integrity_check_linux 
 wants use too, this caused this the problem above. Solving this problem would require 
-making changes to files that will effect other built in scripts. So a quick solution is 
+making changes to files that will affect other built in scripts. So a quick solution is 
 to just pass anything as an argument to the script. This will have no effect on our 
 script as we do not make use of the $arg variable.
 

--- a/docs/manual/checkpoint.rst
+++ b/docs/manual/checkpoint.rst
@@ -3,6 +3,10 @@
 Configuring Checkpoint
 ----------------------
 
+.. warning::
+
+   This document does not provide a Checkpoint version, and may be out of date.
+   Please check the vendor's documentation for more up to date information.
 
 Run this command:
 ^^^^^^^^^^^^^^^^^

--- a/docs/manual/notes/portscan_detection.rst
+++ b/docs/manual/notes/portscan_detection.rst
@@ -550,13 +550,13 @@ More restrictions:
 
 iplog.conf:
 ^^^^^^^^^^^
-To Enable  or  disable  a mechanism that attempts to fool programs, such as nmap and queso, that perform remote OS detection, add the follow line to iplog.conf
+To Enable or disable a mechanism that attempts to fool programs, such as nmap and queso, that perform remote OS detection, add the follow line to iplog.conf
 
 .. code-block:: console
 
  set fool_nmap true
 
-As  a side effect, enabling this option will also cause most of nmap's stealth" scans to fail.
+As a side effect, enabling this option will also cause most of nmap's stealth" scans to fail.
 
 BSD's sysctl (some FreeBSD especific):
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add a warning for the Checkpoint steps because I have no idea what version they work on.
Get rid of some unnecessary double spaces.
effect to affect