### PR TITLE
dcid blog post has gone missing

### DIFF
--- a/docs/syntax/rules.trst
+++ b/docs/syntax/rules.trst
@@ -385,7 +385,7 @@
 
     **Usage:** <check_diff />
 
-    **Additional info:** `Daniel Cid <http://dcid.me/2010/03/alerting-when-a-log-or-output-of-a-command-changes/>`_ has written a blog post about the feature.
+ ..   **Additional info:** `Daniel Cid <http://dcid.me/2010/03/alerting-when-a-log-or-output-of-a-command-changes/>`_ has written a blog post about the feature.
 
 .. xml:element:: group 
 


### PR DESCRIPTION
As reported on the user-list by srikanth kalangi <srikanthkalangi gmail>, this blog post now 404s.