### PR TITLE
Add a note about resolving hostnames from /etc/hosts.

### DIFF
--- a/docs/faq/agents.rst
+++ b/docs/faq/agents.rst
@@ -20,6 +20,12 @@ ossec-logcollector(PID): ERROR: Unable to open file '/queue/ossec/.agent_info'
 Ensure there is a <server-ip> configured in the agent's /var/ossec/etc/ossec.conf, and that the IP is correct.
 
 
+The OSSEC agent is unable to resolve hostnames from /etc/hosts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default OSSEC chroots many of its daemons to `/var/ossec`. When this happens the `/etc/hosts` file is unreadable.
+To resolve this issue, copy `/etc/hosts` to `/var/ossec/etc/`. A hardlink to `/etc/hosts` can be used if the system
+is does not have a separate `/var/` partition.
 
 
 


### PR DESCRIPTION
 Either copyingthe file or a hardlink is necessary. But /var/ is its own partition
on any sane system, so hardlinks are frowned upon.