### PR TITLE
authd options incorrectly labeled as available after 2.8.1

### DIFF
--- a/docs/programs/ossec-authd.rst
+++ b/docs/programs/ossec-authd.rst
@@ -62,7 +62,7 @@ ossec-authd argument options
 
     .. note::
 
-       This option was added after 2.8.1.
+       This option is available in OSSEC 2.9.
 
 .. option:: -x <path>
 
@@ -70,7 +70,7 @@ ossec-authd argument options
 
     .. note::
 
-       This option was added after 2.8.1.
+       This option is available in OSSEC 2.9.
 
 
 


### PR DESCRIPTION
I don't see them in 2.8.2. Brought up on the user list by Schwegler Ruedi <Ruedi.Schwegler at aspectra ch>