### PR TITLE
Replace sample IPv4-dependent regular expressions \d+.\d+.\d+.\d+ with \S+

### DIFF
--- a/docs/log_samples/security_devices/iplog.rst
+++ b/docs/log_samples/security_devices/iplog.rst
@@ -334,7 +334,7 @@ Nov 14 15:57:56 TCP: Bogus TCP flags set by 10.10.160.2:60873 (dest port 25)
 
  <decoder name="iplog-bogustcp">
   <prematch>Bogus TCP flags set by</prematch>
-  <regex offset="after_prematch">(\d+.\d+.\d+.\d+):\d+</regex>
+  <regex offset="after_prematch">(\S+):\d+</regex>
   <order>srcip</order>
  </decoder>
 

--- a/docs/manual/notes/decoder_rule_relation.rst
+++ b/docs/manual/notes/decoder_rule_relation.rst
@@ -26,8 +26,8 @@ The first rule acts as a "collector" for specific log messages.  As part of the 
 
  <decoder name="web-accesslog">
    <type>web-log</type>
-   <prematch>^\d+.\d+.\d+.\d+ - </prematch>
-   <regex>^(\d+.\d+.\d+.\d+) - \S+ [\S+ -\d+] </regex>
+   <prematch>^\S+ - </prematch>
+   <regex>^(\S+) - \S+ [\S+ -\d+] </regex>
    <regex>"\w+ (\S+) HTTP\S+ (\d+) </regex>
    <order>srcip,url,id</order>
  </decoder>

--- a/docs/manual/notes/portscan_detection.rst
+++ b/docs/manual/notes/portscan_detection.rst
@@ -348,7 +348,7 @@ a proppossed decoder is (not tested):
 
  <decoder name="iplog-bogustcp">
   <prematch>Bogus TCP flags set by</prematch>
-  <regex offset="after_prematch">(\d+.\d+.\d+.\d+):\d+</regex>
+  <regex offset="after_prematch">(\S+):\d+</regex>
   <order>srcip</order>
  </decoder>
 


### PR DESCRIPTION
The existing example regular expressions are IPv4 specific and would miss IPv6 addresses in the logs.