### PR TITLE
Warn that use_fqdn was added in 2.9.0

### DIFF
--- a/docs/syntax/example_ossec_config.active-response.trst
+++ b/docs/syntax/example_ossec_config.active-response.trst
@@ -82,7 +82,7 @@ This active-response will run on agent ``001`` only.
     <rules_group>authentication_failed,authentication_failures</rules_group>
   </active-response>
 
-.. warning:
+.. warning::
 
     This may trigger on a single authentication failure.
 
@@ -159,7 +159,7 @@ It also uses the ``repeated_offenders`` option blocking an IP for 30 minutes on 
    </active-response>
 
 
-.. warning:
+.. warning::
 
     This may trigger on a single authentication failure.
 

--- a/docs/syntax/ossec_config.syslog_output.trst
+++ b/docs/syntax/ossec_config.syslog_output.trst
@@ -56,6 +56,10 @@
 
     - **Allowed** yes, no
 
+    .. warning::
+
+       This option was added in OSSEC 2.9.0.
+
 .. xml:element:: format
 
     - Format of alert output. The default format is "default", or full syslog output.


### PR DESCRIPTION
Prompted by issue 708 on ossec-hids repo. Fixes issue #130 here.