### PR TITLE
Fix typos

### DIFF
--- a/docs/syntax/ossec_config.syscheck.trst
+++ b/docs/syntax/ossec_config.syscheck.trst
@@ -78,7 +78,7 @@
 .. object:: nodiff
 
     .. versionadded:: 3.0
-    List of files to not attach a diff. The files are still checked, but no diff is computed. This allows to monitor sensible files like private key or database configuration without leaking sensible data through alerts.
+    List of files to not attach a diff. The files are still checked, but no diff is computed. This allows to monitor sensitive files like private key or database configuration without leaking sensitive data through alerts.
 
     **Attributes:**
 


### PR DESCRIPTION
"sensible" doesn't make much sense here, particularly "leaking sensible data"; "sensitive" seems to make more sense here