### PR TITLE
Mention local_internal_options.conf

### DIFF
--- a/docs/syntax/internal_options.rst
+++ b/docs/syntax/internal_options.rst
@@ -4,6 +4,11 @@
 internal_options.conf: syntax and options
 =========================================
 
+The `/var/ossec/etc/internal_options.conf` file includes several options not present int he `ossec.conf`.
+`/var/ossec/etc/local_internal_options.conf` can be used for changes to the defaults, and this file will not
+be overwritten during an upgrade.
+
+
 .. toctree::
     :maxdepth: 2
     :glob:


### PR DESCRIPTION
This file can be used to make changes to internal_options.conf and shouldn't be overwritten during an upgrade.