### PR TITLE
Weekday to weekdays, AR syntax correction

### DIFF
--- a/docs/syntax/ossec_config.active-response.trst
+++ b/docs/syntax/ossec_config.active-response.trst
@@ -70,7 +70,7 @@ Active-response Options
 
 .. xml:element:: rules_group
 
-    The response will be executed on any event in the defined group. Multiple groups can be defined if separated by a comma.
+    The response will be executed on any event in the defined group. Multiple groups can be defined if separated by a pipe (`|`).
 
 .. xml:element:: rules_id
 

--- a/docs/syntax/rules.trst
+++ b/docs/syntax/rules.trst
@@ -135,7 +135,7 @@
 
     - Week day that the event was generated. 
 
-    - **Allowed:** monday - sunday, weekday, weekends
+    - **Allowed:** monday - sunday, weekdays, weekends
 
 .. xml:element:: id 
 


### PR DESCRIPTION
From Issue #187 change weekday to weekdays in the rule syntax docs.
Also document that multiple groups in rules_groups can be added if there is a "|" between them.