### PR TITLE
Document override behavior for syscheck directory check_all

### DIFF
--- a/docs/syntax/ossec_config.syscheck.trst
+++ b/docs/syntax/ossec_config.syscheck.trst
@@ -22,7 +22,7 @@
 
     - **check_all**: Value=yes
 
-        - All the following check_* options are used together unless explicitly overriden with "no".
+        - All the following check_* options are used together unless a specific option is explicitly overriden with "no". 
 
     - **check_sum**: Value=yes
 

--- a/docs/syntax/ossec_config.syscheck.trst
+++ b/docs/syntax/ossec_config.syscheck.trst
@@ -22,7 +22,7 @@
 
     - **check_all**: Value=yes
 
-        - All the following check_* options are used together unless explicitly override with "no".
+        - All the following check_* options are used together unless explicitly overriden with "no".
 
     - **check_sum**: Value=yes
 

--- a/docs/syntax/ossec_config.syscheck.trst
+++ b/docs/syntax/ossec_config.syscheck.trst
@@ -22,7 +22,7 @@
 
     - **check_all**: Value=yes
 
-        - All the following check_* options are used together.
+        - All the following check_* options are used together unless explicitly override with "no".
 
     - **check_sum**: Value=yes
 


### PR DESCRIPTION
Per https://github.com/ossec/ossec-docs/issues/119 and as implemented in https://github.com/ossec/ossec-hids/pull/657 into ossec:master, document the ability to override specific directory check options when `check_all="yes"` in `ossec.conf`.