### PR TITLE
MinGW install steps

### DIFF
--- a/docs/manual/installation/compile-ossec-mingw.rst
+++ b/docs/manual/installation/compile-ossec-mingw.rst
@@ -5,7 +5,7 @@ OSSEC's Windows agent is compiled using `MinGW <http://www.mingw.org/>`_
 
 .. note::
 
-   This documentation assumes you have MinGW installed, and it is usable.
+   This documentation assumes you have MinGW installed, and it is usable. An example of installing MinGW on CentOS is available `here </install-mingw.html>`_
 
 It has always been a pain to generate snapshots for Windows because it required me to open up my Windows VM (slow), push the code there, compile, etc. Well, until this week when I started to play with MinGW cross-compilation feature to completely build an Windows agent from Linux.
 

--- a/docs/manual/installation/install-mingw.rst
+++ b/docs/manual/installation/install-mingw.rst
@@ -1,0 +1,14 @@
+.. _install-mingw: 
+
+This is an example of installing MinGW and required packages for compiling the OSSEC Windows Agent on CentOS 7.
+
+.. code-block:: console
+
+   # yum install epel-release
+   # yum makecache fast
+   # yum install mingw32-gcc.x86_64
+   # yum install mingw32-nsis.x86_64
+   # cd /home/user/ossec-hids-master/src
+   # make clean
+   # make TARGET=winagent
+   # cd win32


### PR DESCRIPTION
Adds a page that describes installing MinGW and related dependencies for building winagent on CentOS 7.