### PR TITLE
Require docutils-0.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-bootstrap-theme==0.4.5
 ablog==0.4
 github3.py==0.9.3
 travis-sphinx==1.1.0
+docutils==0.13.1


### PR DESCRIPTION
Fix travis-ci build by downgrading docutils to 0.13.1. The build host started using 0.14, thereby breaking the build.