### PR TITLE
Add a missing `}`

### DIFF
--- a/docs/cookbooks/recipes/elasticstack.rst
+++ b/docs/cookbooks/recipes/elasticstack.rst
@@ -44,6 +44,7 @@ Configure logstash:
            "[type]" => "osseclogs"
          }
        }
+     }
    }
 
    output {


### PR DESCRIPTION
From @zvanderbilt in the ossec.github.io repository in PR #7 https://github.com/ossec/ossec.github.io/pull/7