### PR TITLE
I had to change the ossec-hids-client to ossec-hids-agent. The Yum re…

### DIFF
--- a/docs/manual/installation/installation-package.rst
+++ b/docs/manual/installation/installation-package.rst
@@ -28,7 +28,7 @@ And for an agent run:
 
 .. code-block:: console
 
-   # yum install ossec-hids ossec-hids-client
+   # yum install ossec-hids ossec-hids-agent
 
 
 Deb Installation


### PR DESCRIPTION
…pos do not know anything about ossec-hids-client.

On CentOS 6:
[vagrant@centos6 ~]$ yum search ossec
Loaded plugins: fastestmirror, security
Determining fastest mirrors
 * atomic: www6.atomicorp.com
 * base: mirrors.tummy.com
 * extras: mirror.jaleco.com
 * updates: centos-distro.1gservers.com
==================================================== N/S Matched: ossec =====================================================
ossec-hids-agent.x86_64 : The OSSEC HIDS Client
ossec-hids-debuginfo.x86_64 : Debug information for package ossec-hids
ossec-hids-hybrid.x86_64 : The OSSEC HIDS hybrid client
ossec-hids-mysql.x86_64 : The OSSEC HIDS Server mysql connector
ossec-hids-postgres.x86_64 : The OSSEC HIDS Server postgres connector
ossec-hids-server.x86_64 : The OSSEC HIDS Server
ossec-wui.noarch : OSSEC Web Interface
ossec-hids.x86_64 : An Open Source Host-based Intrusion Detection System

  Name and summary matches only, use "search all" for everything.
[vagrant@centos6 ~]$

On CentOS7
[vagrant@centos7 ~]$ yum search ossec
Loaded plugins: fastestmirror
Determining fastest mirrors
 * atomic: www6.atomicorp.com
 * base: mirror.hostduplex.com
 * extras: mirrors.usc.edu
 * updates: mirror.dal10.us.leaseweb.net
==================================================== N/S matched: ossec =====================================================
ossec-hids-agent.x86_64 : The OSSEC HIDS Client
ossec-hids-debuginfo.x86_64 : Debug information for package ossec-hids
ossec-hids-hybrid.x86_64 : The OSSEC HIDS hybrid client
ossec-hids-mysql.x86_64 : The OSSEC HIDS Server mysql connector
ossec-hids-postgres.x86_64 : The OSSEC HIDS Server postgres connector
ossec-hids-server.x86_64 : The OSSEC HIDS Server
ossec-wui.noarch : OSSEC Web Interface
ossec-hids.x86_64 : An Open Source Host-based Intrusion Detection System

  Name and summary matches only, use "search all" for everything.
[vagrant@centos7 ~]$

As such, the instruction to run "yum -y install ossec-hids-client" is incorrect for RedHat family systems.