### PR TITLE
Clarify rules execution order, and noalert attribute

### DIFF
--- a/docs/manual/rules-decoders/testing.rst
+++ b/docs/manual/rules-decoders/testing.rst
@@ -80,7 +80,7 @@ to follow the log through the rule path:
 
 .. code-block:: console 
 
-    # /var/ossec/bin/ossec-logtest -f
+    # /var/ossec/bin/ossec-logtest -v
     2008/07/04 10:05:43 ossec-testrule: INFO: Started (pid: 23007).
     ossec-testrule: Type one log per line.
 

--- a/docs/syntax/head_rules.rst
+++ b/docs/syntax/head_rules.rst
@@ -7,6 +7,12 @@ Rules Syntax
 Overview 
 --------
 
+Order of execution
+^^^^^^^^^^^^^^^^^^
+
+First, the rules with 0 levels are tried, and then all the other rules in a decreasing order by their level.
+If the level is the same, the order will be decided based on the rules list in /var/ossec/etc/ossec.conf file.
+Note, for rules which have some requirement (for example if_sid), the requirement is tried first.
 
 Options 
 ------- 

--- a/docs/syntax/rules.trst
+++ b/docs/syntax/rules.trst
@@ -37,6 +37,12 @@
           .. note::
              More information about how frequency is counted can be found `in this thread. <http://marc.info/?l=ossec-list&m=129736702512080&w=2>`_
 
+    - *noalert* 
+
+        - Specifies whether the rule generates an alert or not in a sense, that if it does, no new rules are tried, except the rules which specify this in their if_sid. Setting this to 1 is useful if trying other rules are the sensible thing to do if this one matches, but it's child rules (rules which specify this in their if_sid) do not.
+        - **Allowed:** 0 or 1 
+        - **Default:** 0 
+
 
 
     .. _timeframe:


### PR DESCRIPTION
The Overview section of the Rules Syntax have been improved by a small
description in which order the rules are tried, and matched.
The noalert attribute with description has been added to the rules
specification too.
In the Testing OSSEC rules/decoders section, the -f argument has been
changed to -v, because -f is not a valid argument for ossec-logtest.