### PR TITLE
adding *BSD systems to OSSEC HIDS docs

### DIFF
--- a/docs/manual/installation/installation-package.rst
+++ b/docs/manual/installation/installation-package.rst
@@ -72,5 +72,19 @@ Or install OSSEC HIDS agent:
 
     # apt-get install ossec-hids-agent
 
+pkg Installation
+----------------
 
+Some of the BSD operating systems offer OSSEC packages you can use. Here you have FreeBSD as example.
+
+* **FreeBSD**
+
+You are going to work together with ``pkg`` here. Just choose which type of setup you need
+(agent, local monitoring, or server/manager) and install the respective OSSEC package.
+
+Should you opt to install an OSSEC Server/Manager:
+
+.. code-block:: console
+
+   # pkg install ossec-hids-server
 

--- a/docs/manual/installation/installation-package.rst
+++ b/docs/manual/installation/installation-package.rst
@@ -88,3 +88,9 @@ Should you opt to install an OSSEC Server/Manager:
 
    # pkg install ossec-hids-server
 
+If you want to install an OSSEC Agent:
+
+.. code-block:: console
+
+   # pkg install ossec-hids-agent
+

--- a/docs/manual/installation/installation-package.rst
+++ b/docs/manual/installation/installation-package.rst
@@ -75,7 +75,8 @@ Or install OSSEC HIDS agent:
 pkg Installation
 ----------------
 
-Some of the BSD operating systems offer OSSEC packages you can use. Here you have FreeBSD as example.
+Some of the BSD operating systems offer OSSEC packages you can use. Here you have
+FreeBSD and OpenBSD as example.
 
 * **FreeBSD**
 
@@ -93,4 +94,14 @@ If you want to install an OSSEC Agent:
 .. code-block:: console
 
    # pkg install ossec-hids-agent
+
+* **OpenBSD**
+
+Here you must work with ``pkg_add`` instead of `pkg`, but no worries it's the same concept.
+
+As it only offers one package, here is how to install OSSEC HIDS on OpenBSD:
+
+.. code-block:: console
+
+   # pkg_add ossec-hids
 

--- a/docs/manual/installation/installation-package.rst
+++ b/docs/manual/installation/installation-package.rst
@@ -95,6 +95,11 @@ If you want to install an OSSEC Agent:
 
    # pkg install ossec-hids-agent
 
+.. note::
+
+   These steps also work for **DragonFlyBSD**. It also uses ``pkg``, just like FreeBSD. You can
+   read more about it `here <https://www.dragonflybsd.org/docs/howtos/HowToDPorts/>`_.
+
 * **OpenBSD**
 
 Here you must work with ``pkg_add`` instead of `pkg`, but no worries it's the same concept.

--- a/docs/manual/installation/installation-requirements.rst
+++ b/docs/manual/installation/installation-requirements.rst
@@ -156,6 +156,23 @@ FreeBSD also offers pre-compiled packages for OSSEC and all its dependencies. If
 want to install them you must work with
 `pkg <https://www.freebsd.org/doc/handbook/pkgng-intro.html>`_.
 
+OpenBSD
+-------
+
+As OpenBSD also has its own `Ports Collection <https://www.openbsd.org/faq/ports/ports.html>`_,
+you can build and install OSSEC using it if you want.
+
+It only offers **security/ossec-hids**, so:
+
+.. code-block:: console
+
+   # cd /usr/ports/security/ossec-hids
+   # make
+
+Just like the previous example with FreeBSD, if you want to install it all (not just the
+dependencies) you must run ``make install`` instead. Another option would be using
+`pkg_add <https://www.openbsd.org/faq/faq15.html>`_.
+
 Debian
 ------
 

--- a/docs/manual/installation/installation-requirements.rst
+++ b/docs/manual/installation/installation-requirements.rst
@@ -133,6 +133,29 @@ need to be installed.
 
    # zypper install postgresql-devel mysql-devel
 
+FreeBSD
+-------
+
+If you want to build and install OSSEC on FreeBSD you can work together with
+its `Ports Collection <https://www.freebsd.org/ports>`_.
+
+There you can find and setup **ossec-hids-agent**, **ossec-hids-local** or
+**ossec-hids-server**.
+
+If you want to build and install only the the required dependencies to run an
+OSSEC server/manager, without installing it:
+
+.. code-block:: console
+
+   # cd /usr/ports/security/ossec-hids-server
+   # make
+
+If you want to install this particular port, you should run ``make install``.
+
+FreeBSD also offers pre-compiled packages for OSSEC and all its dependencies. If you
+want to install them you must work with
+`pkg <https://www.freebsd.org/doc/handbook/pkgng-intro.html>`_.
+
 Debian
 ------
 


### PR DESCRIPTION
this PR covers **DragonFlyBSD**, **FreeBSD** and **OpenBSD** setups; builds just fine.

it introduces the use of _Ports_ to deal with "installing dependencies" steps, and uses `pkg` (or `pkg_add`) to install pre-compiled versions of OSSEC HIDS, when there's a package available.