### PR TITLE
Fix the rules and decoders pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -27,19 +27,19 @@ import sphinx_bootstrap_theme
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-#sys.path.append(".")
+sys.path.append(".")
 sys.path.append("docs")
-#extensions = [
-#    'sphinx.ext.autodoc', 
-#    'sphinx.ext.intersphinx', 
-#    'sphinx.ext.todo',
-#    'sphinx.ext.pngmath', 
-#    'sphinx.ext.ifconfig', 
-#    'sphinx.ext.viewcode',
-#    "sphinx.ext.graphviz", 
-#    "sphinx.ext.extlinks",
-#    "_ext.xml_domain",
-#]
+extensions = [
+    'sphinx.ext.autodoc', 
+    'sphinx.ext.intersphinx', 
+    'sphinx.ext.todo',
+    #'sphinx.ext.pngmath', 
+    'sphinx.ext.ifconfig', 
+    'sphinx.ext.viewcode',
+    "sphinx.ext.graphviz", 
+    "sphinx.ext.extlinks",
+    "_ext.xml_domain",
+]
 
 
 # if os.environ.get('READTHEDOCS', None) == 'True':

--- a/docs/syntax/decoders.trst
+++ b/docs/syntax/decoders.trst
@@ -2,7 +2,7 @@
 
     **Attributes:** 
 
-    - *id:*: 
+    - *id*: 
 
     - *name*:
 

--- a/docs/syntax/rules.trst
+++ b/docs/syntax/rules.trst
@@ -246,6 +246,7 @@
     **Attributes:**
 
     .. _list-field:
+
     - *field* 
         
         Field that is used as the key to look up in the CDB file:
@@ -264,6 +265,7 @@
         - Value: action 
 
     .. _list-lookup:
+
     - *lookup*
         
         This is the type of lookup that is preformed: 
@@ -303,6 +305,7 @@
                This feature is not yet complete.
 
     .. _list-check_value:
+
     - *check_value* 
         
         - regex pattern for matching on the value pulled out of the cdb when using lookup types: address_match_key_value, match_key_value


### PR DESCRIPTION
The options for rules and decoders were not showing up. Re-enable the extension that allows these pages to be built.