### PR TITLE
Add a note about cleaning out the src directory before re-compiling.

### DIFF
--- a/docs/manual/output/database-output.rst
+++ b/docs/manual/output/database-output.rst
@@ -34,6 +34,8 @@ You must have the MySQL or PgSQL Client libraries installed on the OSSEC server.
 
 
 You then need to set the DATABASE environment variable and run the "./install.sh" script, to compile OSSEC with the appropriate database support. 
+
+
 If OSSEC had been previously compiled without database support the files created during the previous build should be removed from the `src` directory.
 
 .. code-block:: console

--- a/docs/manual/output/database-output.rst
+++ b/docs/manual/output/database-output.rst
@@ -34,6 +34,14 @@ You must have the MySQL or PgSQL Client libraries installed on the OSSEC server.
 
 
 You then need to set the DATABASE environment variable and run the "./install.sh" script, to compile OSSEC with the appropriate database support. 
+If OSSEC had been previously compiled without database support the files created during the previous build should be removed from the `src` directory.
+
+.. code-block:: console
+
+   # cd src
+   # make clean
+
+Once the old files have been removed, the installation can be performed.
 
 .. code-block:: console 
 


### PR DESCRIPTION
Specifically in the case of adding database output after a previous compilation.
Brought to my attention on the OSSEC mailing list by Natassia M Stelmaszek.