### PR TITLE
Pcre doc fix

### DIFF
--- a/docs/manual/installation/installation-requirements.rst
+++ b/docs/manual/installation/installation-requirements.rst
@@ -26,7 +26,7 @@ To do this the `pcre2-10.32` sources must be installed in `src/external`:
 
 .. code-block:: console
 
-   $ cd ossec-hids-*/src
+   $ cd ossec-hids-*
    $ wget https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz
    $ tar xzf pcre2-10.32.tar.gz -C src/external
 

--- a/docs/manual/installation/installation-requirements.rst
+++ b/docs/manual/installation/installation-requirements.rst
@@ -30,6 +30,13 @@ To do this the `pcre2-10.32` sources must be installed in `src/external`:
    $ wget https://ftp.pcre.org/pub/pcre/pcre2-10.32.tar.gz
    $ tar xzf pcre2-10.32.tar.gz -C src/external
 
+If you use the `pcre2-10.32` sources, set the `PCRE2_SYSTEM` variable to no:
+
+.. code-block:: console
+
+   # cd ossec-hids-*
+   # PCRE2_SYSTEM=no ./install.sh
+
 To use the system's PCRE2, set the `PCRE2_SYSTEM` variable to yes:
 
 .. code-block:: console


### PR DESCRIPTION
Two small fixes to the PCRE2 info in the installation doc.

The path to the `src/external` dir is incorrect in the tar extraction, as you had already `cd`'d into `src` before that.

Secondly, as per https://github.com/ossec/ossec-hids/issues/1663#issuecomment-618788023 , it seems that `PCRE2_SYSTEM` defaults to `yes` now. This means that if the system pcre2 is missing (even if you fetched the pcre2 tarball to build it locally, rather than rely on the system's pcre2), then the Makefile will continue to throw an error until `PCRE2_SYSTEM=no` is explicitly set.