### PR TITLE
Update testing.rst

### DIFF
--- a/docs/manual/rules-decoders/testing.rst
+++ b/docs/manual/rules-decoders/testing.rst
@@ -75,7 +75,7 @@ user logoff message from Windows:
     **Alert to be generated.
 
 
-In addition to the information above, `ossec-logtest -f` can be used 
+In addition to the information above, `ossec-logtest -v` can be used 
 to follow the log through the rule path:
 
 .. code-block:: console 


### PR DESCRIPTION
ossec-logtest does not have -f option. Aligned with the example which uses -v option.