### PR TITLE
Use correct command during installation

### DIFF
--- a/docs/manual/installation/installation-package.rst
+++ b/docs/manual/installation/installation-package.rst
@@ -52,7 +52,7 @@ Install OSSEC HIDS server/manager:
 
 .. code-block:: console
 
-    # apt-get install ossec-hids
+    # apt-get install ossec-hids-server
 
 Or install OSSEC HIDS agent:
 


### PR DESCRIPTION
Bit of a rough corner to have this be the first thing that folks on Ubuntu do. I found the correct name with `apt-cache search ossec`, but I'm not sure everybody would be able to figure that out. 