### PR TITLE
Fix USB monitoring example to use local ossec.conf

### DIFF
--- a/docs/manual/monitoring/process-monitoring.rst
+++ b/docs/manual/monitoring/process-monitoring.rst
@@ -143,7 +143,7 @@ can be done in a much easier way with our new :xml:`check_diff` feature.
 To get started, configure each Windows agent to monitor the USBSTOR registry entry
 using the ``reg`` command. This must be in the agent's local ``ossec.conf`` — the
 manager cannot push ``command`` or ``full_command`` localfile entries through
-``agent.conf`` (see :ref:`full_command`).
+``agent.conf`` (see :ref:`ossec_config.localfile`).
 
 .. code-block:: xml 
 


### PR DESCRIPTION
The process-monitoring USB example placed a full_command localfile inside agent_config, but OSSEC rejects remote command localfile entries pushed from the manager via agent.conf. Configure the localfile on each Windows agent's ossec.conf and link to the localfile restriction.

Closes #309

Assisted-By: Auto