### PR TITLE
Document secure vs syslog remote connection types

### DIFF
--- a/docs/manual/agent/remoted-architecture.rst
+++ b/docs/manual/agent/remoted-architecture.rst
@@ -4,7 +4,8 @@ Remoted architecture and tuning
 ===============================
 
 ``ossec-remoted`` receives events from OSSEC agents (secure mode) and from remote syslog
-senders (UDP/TCP). Understanding its threading model helps when sizing syslog TCP
+senders (UDP/TCP). See :ref:`ossec_config.remote` for when to use ``secure`` versus
+``syslog``. Understanding its threading model helps when sizing syslog TCP
 forwarders and tuning ``internal_options.conf``.
 
 Process model

--- a/docs/syntax/head_ossec_config.remote.rst
+++ b/docs/syntax/head_ossec_config.remote.rst
@@ -31,6 +31,24 @@ XML excerpt to show location:
         </remote> 
     </ossec_config> 
 
+Choosing connection type
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``<connection>`` element selects how ``ossec-remoted`` accepts inbound events:
+
+**secure** (default, port 1514)
+    Use for **OSSEC agents**. Traffic uses the OSSEC agent protocol with optional
+    encryption (AES or Blowfish). Agents authenticate with keys from ``client.keys``.
+
+**syslog** (default port 514, UDP or TCP)
+    Use for **external devices** — firewalls, routers, switches, and other syslog
+    senders that are not OSSEC agents. There is no agent key exchange; restrict
+    sources with ``allowed-ips`` and ``deny-ips``.
+
+You can define multiple ``<remote>`` blocks (for example, one ``secure`` listener for
+agents and one ``syslog`` listener for network gear). See also
+:ref:`manual-remoted` for threading and tuning.
+
 Options 
 ------- 
 


### PR DESCRIPTION
Explain when to use secure (OSSEC agents) versus syslog (external devices) in remote options and cross-link from remoted architecture.

Closes #171

Assisted-By: Auto