### PR TITLE
Document floating latest tag source download URLs.

### DIFF
--- a/docs/manual/installation/install-source.rst
+++ b/docs/manual/installation/install-source.rst
@@ -18,6 +18,17 @@ More information on them can be found on the `OSSEC Architecture page <../ossec-
 
 1. Download the latest version and verify its GPG signature (see below).
 
+   Convenience source archives always track the current stable release via the
+   floating ``latest`` tag:
+
+   .. code-block:: console
+
+      curl -LO https://github.com/ossec/ossec-hids/archive/latest.tar.gz
+      curl -LO https://github.com/ossec/ossec-hids/archive/latest.zip
+
+   For GPG verification, download the versioned release tarball and matching
+   ``.asc`` from GitHub Releases (see "Verify the tarball signature" below).
+
 2. Verify the requirements listed in :ref:`install_req` are installed or available.
 
    .. versionadded: 3.3

--- a/docs/manual/installation/installation-binary.rst
+++ b/docs/manual/installation/installation-binary.rst
@@ -27,8 +27,8 @@ install and unpack it (on the system with a compiler).
 
 .. code-block:: console 
 
-    # wget -U ossec http://www.ossec.net/files/ossec-hids-2.8.1.tar.gz
-    # tar -zxvf ossec-hids-latest.tar.gz 
+    # curl -LO https://github.com/ossec/ossec-hids/archive/latest.tar.gz
+    # tar -zxvf latest.tar.gz
 
     
 Enter in the source directory of the downloaded package, and configure OSSEC to build the ``agent`` version.


### PR DESCRIPTION
Use GitHub archive/latest.tar.gz|.zip for convenience downloads (ossec-hids#2042).