### PR TITLE
Document syslog_output server hostname support.

### DIFF
--- a/docs/syntax/ossec_config.syslog_output.trst
+++ b/docs/syntax/ossec_config.syslog_output.trst
@@ -4,9 +4,11 @@
 
    - server
 
-       - IP Address of the syslog server. 
+       - Hostname or IP address of the syslog server.
 
-       - **Allowed:** any valid IP address 
+       - Hostnames are resolved once at startup (before chroot).
+
+       - **Allowed:** any valid hostname or IP address
 
    - port
 


### PR DESCRIPTION
Hostnames are resolved at csyslogd startup before chroot (ossec-hids#1744).