### PR TITLE
Document dedicated OSSEC iptables chain for firewall-drop.

### DIFF
--- a/docs/manual/ar/ar-scripts.rst
+++ b/docs/manual/ar/ar-scripts.rst
@@ -14,7 +14,7 @@ Firewall and network blocking
 | Script            | Expect   | Notes                                         |
 +===================+==========+===============================================+
 | host-deny.sh      | srcip    | Adds IP to ``/etc/hosts.deny`` (tcp wrappers) |
-| firewall-drop.sh  | srcip    | iptables, ipfilter, or AIX IPSec (auto-detect)|
+| firewall-drop.sh  | srcip    | iptables ``OSSEC`` chain, ipfilter, AIX IPSec |
 | firewalld-drop.sh | srcip    | Linux with firewalld; enable manually         |
 | nftables-drop.sh  | srcip    | Linux nftables; requires pre-configured sets  |
 | pf.sh             | srcip    | OpenBSD/FreeBSD PF table ``ossec_fwtable``    |

--- a/docs/manual/ar/ar-unix.rst
+++ b/docs/manual/ar/ar-unix.rst
@@ -80,9 +80,18 @@ By default, the ossec hids comes with the following pre-configured
 active-response tools:
 
 - **host-deny.sh**: Adds an IP to the /etc/hosts.deny file (most Unix systems).
-- **firewall-drop.sh** (iptables): Adds an IP to the iptables deny list (Linux 2.4 and 2.6).
+- **firewall-drop.sh** (iptables): Adds an IP to a dedicated ``OSSEC`` iptables chain (Linux).
 - **firewall-drop.sh** (ipfilter): Adds an IP to the ipfilter deny list (FreeBSD, NetBSD and Solaris).
 - **firewall-drop.sh** (ipfw): Adds an IP to the ipfw deny table (FreeBSD).
+
+    .. note::
+
+        On iptables, drops go into chain ``OSSEC`` (created on first use) with a
+        jump from ``INPUT`` and, when IP forwarding is enabled, ``FORWARD``.
+        That keeps active-response blocks out of the main filter chains so
+        configuration-management tools that purge unmanaged rules are less
+        likely to remove them. Override the chain name with the
+        ``OSSEC_FW_CHAIN`` environment variable if needed.
 
     .. note::
 


### PR DESCRIPTION
Matches active-response behavior for #678 (OSSEC_FW_CHAIN override).