### PR TITLE
Document Windows FIM check_acl and NTFS permissions FAQ.

### DIFF
--- a/docs/faq/syscheck.rst
+++ b/docs/faq/syscheck.rst
@@ -122,6 +122,52 @@ Why does auto_ignore not suppress noisy realtime alerts?
 from the realtime monitoring path are not subject to ``auto_ignore``. Use ``<ignore>`` or a
 local rule for files that change frequently in realtime directories.
 
+Can OSSEC monitor Windows Hidden files?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Yes. Syscheck already enumerates and checksums files with the Windows Hidden
+attribute; content changes are reported like any other file.
+
+To **alert when the Hidden (or other) attribute itself changes**, enable
+``check_attrs`` on the monitored directory (Windows agents only). This is not
+part of ``check_all``:
+
+.. code-block:: xml
+
+  <syscheck>
+    <directories check_all="yes" check_attrs="yes" realtime="yes">C:\\path\\to\\watch</directories>
+  </syscheck>
+
+The first scan after enabling ``check_attrs`` may re-baseline those paths
+(attribute field added to the sum). Use FIM maintenance mode or
+``syscheck_control -u`` if you need a quiet transition.
+
+
+Can OSSEC monitor Windows NTFS permissions (ACLs)?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Yes. Enable ``check_acl`` on the monitored directory (Windows agents only).
+This is **not** part of ``check_all``, and it is separate from Unix
+``check_perm`` (POSIX mode bits).
+
+.. code-block:: xml
+
+  <syscheck>
+    <directories check_all="yes" check_acl="yes" realtime="yes">C:\\path\\to\\watch</directories>
+  </syscheck>
+
+OSSEC stores a compact SID-stable digest in the integrity sum and attaches
+human-readable ACE details (including inheritance flags and Added/Removed/Modified
+sections) on change alerts. Account display-name renames without an ACL edit do
+not raise an alert.
+
+The first scan after enabling ``check_acl`` may re-baseline those paths. Use FIM
+maintenance mode or ``syscheck_control -u`` if you need a quiet transition.
+
+
+How do I get alerts for new files?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Add the following to local_rules.xml only if you want a higher alert level than the
 default (5):
 

--- a/docs/syntax/ossec_config.syscheck.trst
+++ b/docs/syntax/ossec_config.syscheck.trst
@@ -17,8 +17,11 @@
 
            Realtime mode alerts immediately on **file content integrity** changes (checksums
            and size) for files already in the syscheck database. Permission, ownership, and
-           group changes are detected on the **next scheduled scan**, not instantly. See
-           :ref:`syscheck-realtime-limits`.
+           group changes are detected on the **next scheduled scan**, not instantly. On
+           Windows, when ``check_attrs="yes"`` is set, attribute changes (for example Hidden)
+           are also eligible for realtime notification; when ``check_acl="yes"`` is set,
+           NTFS DACL/security changes are likewise eligible via
+           ``FILE_NOTIFY_CHANGE_SECURITY``. See :ref:`syscheck-realtime-limits`.
 
     - **report_changes**: Value=yes
 
@@ -66,6 +69,31 @@
 
         - Check the UNIX permission of the files/directories selected.
           On windows this will only check the POSIX permissions.
+
+    - **check_attrs**: Value=yes
+
+        .. versionadded:: 4.3.0
+
+        - On Windows, include ``GetFileAttributes`` bits (Hidden, System,
+          Archive, and related) in the FIM integrity sum so attribute flips
+          alert. Ignored on non-Windows agents. Not enabled by ``check_all``;
+          set explicitly to avoid a one-time baseline churn on upgrade.
+
+        **Allowed:** yes/no
+
+    - **check_acl**: Value=yes
+
+        .. versionadded:: 4.3.0
+
+        - On Windows, monitor NTFS DACL/ACE changes (ALLOW/DENY matrix with
+          inheritance flags). Change detection uses a SID-stable digest in the
+          FIM sum; alert text includes Added/Removed/Modified ACE details when
+          permissions change. Ignored on non-Windows agents (safe in portable
+          ``agent.conf``). Not enabled by ``check_all``; enable explicitly and
+          expect a one-time baseline when first turned on (use FIM maintenance
+          mode or ``syscheck_control -u`` for a quiet transition).
+
+        **Allowed:** yes/no
 
     - **restrict**: Value=string
 


### PR DESCRIPTION
Cover opt-in check_acl syntax, ACE alert details, and first-enable baseline guidance alongside check_attrs.